### PR TITLE
Fix bug of tag_version_prefix is empty

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -o errexit -o pipefail -o nounset
 
-NEW_RELEASE=${GITHUB_REF##*/${INPUT_TAG_VERSION_PREFIX:-v}}
+NEW_RELEASE=${GITHUB_REF_NAME#${INPUT_TAG_VERSION_PREFIX:-v}}
 
 export HOME=/home/builder
 


### PR DESCRIPTION
`git tag 0.0.1` and `tag_version_prefix: ""` will trigger this bug. `${INPUT_TAG_VERSION_PREFIX:-v}` will return 'v' when `$INPUT_TAG_VERSION_PREFIX` is ""

<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

<!-- Describe your changes in detail -->

#### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes #

#### Screenshots (if appropriate)

#### How Has This Been Tested

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
